### PR TITLE
Console Mozilla error in style.css

### DIFF
--- a/themes/neofs-theme/static/css/style.css
+++ b/themes/neofs-theme/static/css/style.css
@@ -11161,12 +11161,6 @@ a.text-dark:hover {
   }
 }
 
-/*# sourceMappingURL=bootstrap.min.css.map */
-
-
-
-
-
 button:focus {
   outline: none !important
 }


### PR DESCRIPTION
We don't use bootstrap.min.css.map now

closes #22

Signed-off-by: Mikhail Petrov <mike@nspcc.ru>
