### PR TITLE
workflows: fix upload to NeoFS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,7 @@ jobs:
           NEOFS_HTTP_GATE: ${{ vars.NEOFS_HTTP_GATE }}
           STORE_OBJECTS_CID: ${{ vars.STORE_OBJECTS_CID }}
           PATH_TO_FILES_DIR: fs.neo.org
+          STRIP_PREFIX: true
           REPLACE_CONTAINER_CONTENTS: true
 
       - name: Attach binary to the release as an asset


### PR DESCRIPTION
gh-push-to-neofs doesn't strip PATH_TO_FILES_DIR from FilePath which leads to uploads using attributes like

  --attributes FilePath=fs.neo.org/images/icons/icon5.svg,ContentType=image/svg+xml

while in fact we need

  --attributes FilePath=images/icons/icon5.svg,ContentType=image/svg+xml

for the site to work properly.