### PR TITLE
content: fix spec links

### DIFF
--- a/content/services.cn.md
+++ b/content/services.cn.md
@@ -16,8 +16,8 @@ draft: false
 
     {{<service_item text="NeoFS Spec" class="row_service_item" subtext="Technical Specification" icon="/images/icons/spec.svg">}}
       <div>
-        <a href="https://http.fs.neo.org/Bj1YwbEZtqx6fwecb3jKo59ZJtz2SgoEB9dj8Q6vYREM/neofs-spec-c57acefc.pdf" style="margin-right: 10px;">Release</a>
-        <a href="https://http.fs.neo.org/Bj1YwbEZtqx6fwecb3jKo59ZJtz2SgoEB9dj8Q6vYREM/neofs-spec-latest.pdf">Latest</a>
+        <a href="https://rest.fs.neo.org/Bj1YwbEZtqx6fwecb3jKo59ZJtz2SgoEB9dj8Q6vYREM/neofs-spec-c57acefc.pdf" style="margin-right: 10px;">Release</a>
+        <a href="https://rest.fs.neo.org/Bj1YwbEZtqx6fwecb3jKo59ZJtz2SgoEB9dj8Q6vYREM/neofs-spec-latest.pdf">Latest</a>
       </div>
     {{</service_item>}}
   {{</service_items_flex>}}

--- a/content/services.en.md
+++ b/content/services.en.md
@@ -16,8 +16,8 @@ draft: false
 
     {{<service_item text="NeoFS Spec" class="row_service_item" subtext="Technical Specification" icon="/images/icons/spec.svg">}}
       <div>
-        <a href="https://http.fs.neo.org/Bj1YwbEZtqx6fwecb3jKo59ZJtz2SgoEB9dj8Q6vYREM/neofs-spec-c57acefc.pdf" style="margin-right: 10px;">Release</a>
-        <a href="https://http.fs.neo.org/Bj1YwbEZtqx6fwecb3jKo59ZJtz2SgoEB9dj8Q6vYREM/neofs-spec-latest.pdf">Latest</a>
+        <a href="https://rest.fs.neo.org/Bj1YwbEZtqx6fwecb3jKo59ZJtz2SgoEB9dj8Q6vYREM/neofs-spec-c57acefc.pdf" style="margin-right: 10px;">Release</a>
+        <a href="https://rest.fs.neo.org/Bj1YwbEZtqx6fwecb3jKo59ZJtz2SgoEB9dj8Q6vYREM/neofs-spec-latest.pdf">Latest</a>
       </div>
     {{</service_item>}}
   {{</service_items_flex>}}


### PR DESCRIPTION
http.fs.neo.org is long gone.